### PR TITLE
add: 싱글 스레드 서버 뼈대

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,32 +2,85 @@ use std::net::TcpListener;
 use std::io::{Read, Write, ErrorKind};
 use std::fs::File;
 use std::io;
+use std::error::Error;
 
-fn main() {
-    match run() {
-        Ok(()) => {}
+fn main() -> Result<(), Box<dyn Error>> {
+    let result = run();
+    return match result {
+        Ok(()) => Ok(()),
         Err(error) => {
             match error.kind() {
                 ErrorKind::AddrInUse => {
-                    println!("port 7878 in use!!!");
+                    println!("* port 7878 in use!!! \n\trecoverable err : {}", error);
                     // error handling code should follow
                 }
                 ErrorKind::NotFound => {
-                    println!("file not found");
-                    // error handling code should follow
+                    println!("* file not found : \n\tunrecoverable err : {}", error);
+                    // panic code should follow
+                    panic!("unrecoverable error: {}", error);
                 }
-                _ => { println!("error ${:?}", error.kind())}
+                _ => {
+                    panic!("unrecoverable error: {}", error);
+                }
             }
+            Err(Box::new(error))
         }
-    }
+    };
+
+    // return match run().map_err(|error| {
+    //     return match error.kind() {
+    //         ErrorKind::AddrInUse => {
+    //             println!("* port 7878 in use!!! \n\trecoverable err : {}", &error);
+    //             // error handling code should follow
+    //             error
+    //         }
+    //         ErrorKind::NotFound => {
+    //             println!("* file not found : \n\tunrecoverable err : {}", &error);
+    //             // panic code should follow
+    //             panic!("unrecoverable error: {}", error);
+    //         }
+    //         _ => {
+    //             panic!("error ${:?}", error.kind());
+    //         }
+    //     };
+    // }) {
+    //     Ok(()) => return {
+    //         Ok(())
+    //     },
+    //     Err(error) => Err(Box::new(error))
+    // };
+
+    // return match run() {
+    //     Ok(()) => Ok(()),
+    //     Err(error) => {
+    //         match error.kind() {
+    //             ErrorKind::AddrInUse => {
+    //                 println!("port 7878 in use!!!");
+    //                 // error handling code should follow
+    //                 Err(Box::new(error))
+    //             }
+    //             ErrorKind::NotFound => {
+    //                 println!("file not found");
+    //                 // error handling code should follow
+    //                 Err(Box::new(error))
+    //             }
+    //             _ => { println!("error ${:?}", error.kind());
+    //                 Err(Box::new(error))
+    //             }
+    //         }
+    //     }
+    // };
 }
 
 fn run() -> Result<(), io::Error> {
     let listener = match TcpListener::bind("127.0.0.1:7878") {
-       Ok(listener)  => { println!("listening at 7878!!!", ); listener }
-       Err(error) => {
-          return Err(error);
-       }
+        Ok(listener) => {
+            println!("listening at 7878!!!", );
+            listener
+        }
+        Err(error) => {
+            return Err(error);
+        }
     };
 
     for stream in listener.incoming() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,106 +3,36 @@ use std::io::{Read, Write};
 use std::fs::File;
 
 fn main() {
-    let listener = match TcpListener::bind("127.0.0.1:7878") {
-        Ok(tcp_listener) => {
-            println!("* listener is up: \n\t{:?}", &tcp_listener);
-            tcp_listener
-        }
-        Err(err) => {
-            println!("failed:{:?}", err);
-            panic!("error");
-        }
-    };
+    run();
+}
+
+fn run() {
+    let listener = TcpListener::bind("127.0.0.1:7878").map(|listener| {
+        println!("listening at 7878!!!");
+        listener
+    }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
 
     for stream in listener.incoming() {
-        let mut stream = match stream {
-            Ok(tcp_stream) => {
-                println!("* connection established!: \n\t{:?}", &tcp_stream);
-                tcp_stream
-            }
-            Err(err) => {
-                println!("failed:{:?}", err);
-                panic!("error");
-            }
-        };
-
+        let mut stream = stream.map(|stream| {
+            println!("connection established!!!");
+            stream
+        }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
         let mut buffer = [0; 512];
-        match stream.read(&mut buffer) {
-            Ok(buffer_size) => {
-                println!("* read stream \n\tbuffer size: {:?}", &buffer_size);
-                buffer_size
-            }
-            Err(err) => {
-                println!("failed:{:?}", err);
-                panic!("error");
-            }
-        };
+        let _ = stream.read(&mut buffer).map_err(|error| { panic!("error!!! {:?}", error) });
 
         let get = b"GET / HTTP/1.1\r\n";
-
         let (status_line, filename) = if buffer.starts_with(get) {
             ("HTTP/1.1 200 OK\r\n\r\n", "index.html")
         } else {
             ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
         };
 
-        let mut file = match File::open(filename) {
-            Ok(file) => {
-                println!("* get handler for local file\n\tfile: {:?}", &file);
-                file
-            }
-            Err(err) => {
-                println!("failed:{:?}", err);
-                panic!("error");
-            }
-        };
+        let mut file = File::open(filename).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
         let mut contents = String::new();
 
-        match file.read_to_string(&mut contents) {
-            Ok(buffer_size) => {
-                println!("* read buffer from local file into string container\n\tbuffer size: {:?}", &buffer_size);
-                buffer_size
-            }
-            Err(err) => {
-                println!("failed:{:?}", err);
-                panic!("error");
-            }
-        };
+        let response: String = file.read_to_string(&mut contents).map(|_usize| { format!("{}{}", status_line, contents) }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
 
-        let response = format!("{}{}", status_line, contents);
-
-        match stream.write(response.as_bytes()) {
-            Ok(buffer_size) => {
-                println!("* write response from string into stream\n\tbuffer size: {:?}", &buffer_size);
-                buffer_size
-            }
-            Err(err) => {
-                println!("failed:{:?}", err);
-                panic!("error");
-            }
-        };
-        match stream.flush() {
-            Ok(t) => {
-                println!("* emptied buffer {:?}", &t);
-                t
-            }
-            Err(err) => {
-                println!("failed:{:?}", err);
-                panic!("error");
-            }
-        };
+        let _ = stream.write(response.as_bytes()).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
+        let _ = stream.flush().map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
     }
-    /* (Result.and_then)/
-    // Result.and_then 으로 처리를 이어 나가려면 컨텍스트 객체가 반환되어야 함.
-        pub fn and_then<U, F>(self, op: F) -> Result<U, E>
-        where
-        F: FnOnce(T) -> Result<U, E>,
-    // (sample)
-    fn sq(x: u32) -> Result<u32, u32> { Ok(x * x) }
-    fn err(x: u32) -> Result<u32, u32> { Err(x) }
-
-    assert_eq!(Ok(2).and_then(sq).and_then(sq), Ok(16));
-    assert_eq!(Ok(2).and_then(err).and_then(sq), Err(2));
-    */
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,108 @@
+use std::net::TcpListener;
+use std::io::{Read, Write};
+use std::fs::File;
+
 fn main() {
-    println!("Hello, world!");
+    let listener = match TcpListener::bind("127.0.0.1:7878") {
+        Ok(tcp_listener) => {
+            println!("* listener is up: \n\t{:?}", &tcp_listener);
+            tcp_listener
+        }
+        Err(err) => {
+            println!("failed:{:?}", err);
+            panic!("error");
+        }
+    };
+
+    for stream in listener.incoming() {
+        let mut stream = match stream {
+            Ok(tcp_stream) => {
+                println!("* connection established!: \n\t{:?}", &tcp_stream);
+                tcp_stream
+            }
+            Err(err) => {
+                println!("failed:{:?}", err);
+                panic!("error");
+            }
+        };
+
+        let mut buffer = [0; 512];
+        match stream.read(&mut buffer) {
+            Ok(buffer_size) => {
+                println!("* read stream \n\tbuffer size: {:?}", &buffer_size);
+                buffer_size
+            }
+            Err(err) => {
+                println!("failed:{:?}", err);
+                panic!("error");
+            }
+        };
+
+        let get = b"GET / HTTP/1.1\r\n";
+
+        let (status_line, filename) = if buffer.starts_with(get) {
+            ("HTTP/1.1 200 OK\r\n\r\n", "index.html")
+        } else {
+            ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
+        };
+
+        let mut file = match File::open(filename) {
+            Ok(file) => {
+                println!("* get handler for local file\n\tfile: {:?}", &file);
+                file
+            }
+            Err(err) => {
+                println!("failed:{:?}", err);
+                panic!("error");
+            }
+        };
+        let mut contents = String::new();
+
+        match file.read_to_string(&mut contents) {
+            Ok(buffer_size) => {
+                println!("* read buffer from local file into string container\n\tbuffer size: {:?}", &buffer_size);
+                buffer_size
+            }
+            Err(err) => {
+                println!("failed:{:?}", err);
+                panic!("error");
+            }
+        };
+
+        let response = format!("{}{}", status_line, contents);
+
+        match stream.write(response.as_bytes()) {
+            Ok(buffer_size) => {
+                println!("* write response from string into stream\n\tbuffer size: {:?}", &buffer_size);
+                buffer_size
+            }
+            Err(err) => {
+                println!("failed:{:?}", err);
+                panic!("error");
+            }
+        };
+        match stream.flush() {
+            Ok(t) => {
+                println!("* emptied buffer {:?}", &t);
+                t
+            }
+            Err(err) => {
+                println!("failed:{:?}", err);
+                panic!("error");
+            }
+        };
+    }
+    /* (Result.and_then)/
+    // Result.and_then 으로 처리를 이어 나가려면 컨텍스트 객체가 반환되어야 함.
+        pub fn and_then<U, F>(self, op: F) -> Result<U, E>
+        where
+        F: FnOnce(T) -> Result<U, E>,
+    // (sample)
+    fn sq(x: u32) -> Result<u32, u32> { Ok(x * x) }
+    fn err(x: u32) -> Result<u32, u32> { Err(x) }
+
+    assert_eq!(Ok(2).and_then(sq).and_then(sq), Ok(16));
+    assert_eq!(Ok(2).and_then(err).and_then(sq), Err(2));
+    */
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,34 @@
 use std::net::TcpListener;
-use std::io::{Read, Write};
+use std::io::{Read, Write, ErrorKind};
 use std::fs::File;
+use std::io;
 
 fn main() {
-    run();
+    match run() {
+        Ok(()) => {}
+        Err(error) => {
+            match error.kind() {
+                ErrorKind::AddrInUse => {
+                    println!("port 7878 in use!!!");
+                    // error handling code should follow
+                }
+                ErrorKind::NotFound => {
+                    println!("file not found");
+                    // error handling code should follow
+                }
+                _ => { println!("error ${:?}", error.kind())}
+            }
+        }
+    }
 }
 
-fn run() {
-    let listener = TcpListener::bind("127.0.0.1:7878").map(|listener| {
-        println!("listening at 7878!!!");
-        listener
-    }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
+fn run() -> Result<(), io::Error> {
+    let listener = match TcpListener::bind("127.0.0.1:7878") {
+       Ok(listener)  => { println!("listening at 7878!!!", ); listener }
+       Err(error) => {
+          return Err(error);
+       }
+    };
 
     for stream in listener.incoming() {
         let mut stream = stream.map(|stream| {
@@ -22,12 +40,18 @@ fn run() {
 
         let get = b"GET / HTTP/1.1\r\n";
         let (status_line, filename) = if buffer.starts_with(get) {
-            ("HTTP/1.1 200 OK\r\n\r\n", "index.html")
+            ("HTTP/1.1 200 OK\r\n\r\n", "index2.html")
         } else {
             ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
         };
 
-        let mut file = File::open(filename).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
+        let mut file = match File::open(filename) {
+            Ok(file) => { file }
+            Err(error) => {
+                return Err(error);
+            }
+        };
+
         let mut contents = String::new();
 
         let response: String = file.read_to_string(&mut contents).map(|_usize| { format!("{}{}", status_line, contents) }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
@@ -35,4 +59,5 @@ fn run() {
         let _ = stream.write(response.as_bytes()).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
         let _ = stream.flush().map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
     }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,64 +26,16 @@ fn main() -> Result<(), Box<dyn Error>> {
             Err(Box::new(error))
         }
     };
-
-    // return match run().map_err(|error| {
-    //     return match error.kind() {
-    //         ErrorKind::AddrInUse => {
-    //             println!("* port 7878 in use!!! \n\trecoverable err : {}", &error);
-    //             // error handling code should follow
-    //             error
-    //         }
-    //         ErrorKind::NotFound => {
-    //             println!("* file not found : \n\tunrecoverable err : {}", &error);
-    //             // panic code should follow
-    //             panic!("unrecoverable error: {}", error);
-    //         }
-    //         _ => {
-    //             panic!("error ${:?}", error.kind());
-    //         }
-    //     };
-    // }) {
-    //     Ok(()) => return {
-    //         Ok(())
-    //     },
-    //     Err(error) => Err(Box::new(error))
-    // };
-
-    // return match run() {
-    //     Ok(()) => Ok(()),
-    //     Err(error) => {
-    //         match error.kind() {
-    //             ErrorKind::AddrInUse => {
-    //                 println!("port 7878 in use!!!");
-    //                 // error handling code should follow
-    //                 Err(Box::new(error))
-    //             }
-    //             ErrorKind::NotFound => {
-    //                 println!("file not found");
-    //                 // error handling code should follow
-    //                 Err(Box::new(error))
-    //             }
-    //             _ => { println!("error ${:?}", error.kind());
-    //                 Err(Box::new(error))
-    //             }
-    //         }
-    //     }
-    // };
 }
 
 fn run() -> Result<(), io::Error> {
-    let listener = match TcpListener::bind("127.0.0.1:7878") {
-        Ok(listener) => {
-            println!("listening at 7878!!!", );
+    let listener = TcpListener::bind("127.0.0.1:7878").map(|listener| {
+            println!("listening at 7878!!!");
             listener
         }
-        Err(error) => {
-            return Err(error);
-        }
-    };
+    );
 
-    for stream in listener.incoming() {
+    for stream in listener?.incoming() {
         let mut stream = stream.map(|stream| {
             println!("connection established!!!");
             stream
@@ -93,21 +45,16 @@ fn run() -> Result<(), io::Error> {
 
         let get = b"GET / HTTP/1.1\r\n";
         let (status_line, filename) = if buffer.starts_with(get) {
-            ("HTTP/1.1 200 OK\r\n\r\n", "index2.html")
+            ("HTTP/1.1 200 OK\r\n\r\n", "index.html")
         } else {
             ("HTTP/1.1 404 NOT FOUND\r\n\r\n", "404.html")
         };
 
-        let mut file = match File::open(filename) {
-            Ok(file) => { file }
-            Err(error) => {
-                return Err(error);
-            }
-        };
+        let file = File::open(filename);
 
         let mut contents = String::new();
 
-        let response: String = file.read_to_string(&mut contents).map(|_usize| { format!("{}{}", status_line, contents) }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
+        let response: String = file?.read_to_string(&mut contents).map(|_usize| { format!("{}{}", status_line, contents) }).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
 
         let _ = stream.write(response.as_bytes()).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
         let _ = stream.flush().map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();


### PR DESCRIPTION
### 요약
* 서브루틴 unwrap 에러 처리를 에러 전파 코드로 수정
* 에러 종류에 따른 에러 핸들링이 가능하도록 코드 수정
* 반환 값 있는 함수 호출과 관련하여_ 변수로 경고 제거하도록 코드 수정
* 메인루틴 에러를 에러 코드와 함께 os 레벨로 전파하도록 코드 작성
* Result.and_then() 적용 가능 여부 검토 => 불가

### 참고 자료 

* [싱글 쓰레드 서버](https://doc.rust-lang.org/book/ch20-01-single-threaded.html)
* [에러 종류별로 핸들링 분기](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#matching-on-different-errors)
* [에러 전파하기](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#propagating-errors)
* [? 연산자](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#the--operator-can-be-used-in-functions-that-return-result)
* [os로 에러 코드 전파하기](https://stackoverflow.com/questions/24245276/why-does-rust-not-have-a-return-value-in-the-main-function-and-how-to-return-a/50459909#50459909)
* [unused return value 경고 제거하기](https://news.ycombinator.com/item?id=7792660)
* [and_then()](https://doc.rust-lang.org/std/result/enum.Result.html#method.and_then)

### Todo 

* 테스트 코드 작성
* 멀티 스레드 서버 코드 작성