### PR TITLE
add: test code for the error condition

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1>Oops!</h1>
+<p>Sorry, I don't know what you're asking for.</p>
+</body>
+</html>

--- a/404.html
+++ b/404.html
@@ -9,3 +9,4 @@
 <p>Sorry, I don't know what you're asking for.</p>
 </body>
 </html>
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+reqwest = "0.9"
+
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 [dependencies]
 reqwest = "0.9"
 regex = "1.3.7"
+encoding_rs = "0.8.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,4 @@ edition = "2018"
 
 [dependencies]
 reqwest = "0.9"
-
-
-
+regex = "1.3.7"

--- a/index.html
+++ b/index.html
@@ -9,3 +9,4 @@
 <p>Hi from Rust</p>
 </body>
 </html>
+

--- a/index2.html
+++ b/index2.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<h1>Hello!</h1>
+<p>Hi from Rust</p>
+</body>
+</html>

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,18 +62,20 @@ fn run(domain: &str, port_no: Option<u16>) -> Result<(), io::Error> {
             Some(t) => { t.get(1).map_or("/", |m| m.as_str()) }
             None => { "/" }
         };
-        /*log/ */println!("\t* relative_url: {}", rel_url);
+        // /*log/ */println!("\t* relative_url: {}", rel_url);
 
         let filename = if rel_url == "/" { Cow::from("index.html") } else { Cow::from(format!("{}.html", String::from(rel_url))) /*(rel_url.to_string() + "index2.html").as_str()*/ };
         // /*log/ */println!("filename: {}", &filename.deref());
-        let file = match File::open(filename.deref()) {
-            Ok(file) => { Ok(file) }
-            Err(_) => { File::open("404.html") }
+        let (status_line, mut file) = match File::open(filename.deref()) {
+            Ok(file) => { ("HTTP/1.1 200 OK\r\n\r\n", file) }
+            Err(_) => { ("HTTP/1.1 404 NOT FOUND\r\n\r\n", File::open("404.html").unwrap()) }
         };
-        let mut contents = String::new();
-        let response: String = file?.read_to_string(&mut contents).map(|_usize| { format!("{}{}", "HTTP/1.1 200 OK\r\n\r\n", contents) }).map_err(|error| { panic!("error!!! {:?}", error); }).unwrap();
-        // /*log/ */println!("{}", response);
+        // /*log/ */println!("\t* status_line: {}", status_line);
 
+        let mut contents = String::new();
+        let response: String = file.read_to_string(&mut contents).map(|_usize| { format!("{}{}", status_line, contents) }).map_err(|error| { panic!("error!!! {:?}", error); }).unwrap();
+        // /*log/ */println!("{}", response);
+        //
         let _ = stream.write(response.as_bytes()).map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
         let _ = stream.flush().map_err(|error| { panic!("error!!! {:?}", error) }).unwrap();
     }
@@ -98,42 +100,21 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
-    fn test_file_not_found_error() {
-        thread::sleep(time::Duration::from_millis(2000));
-        let (sndr, rcvr) = mpsc::channel();
-        let _ = thread::spawn(move || {
-            let result = super::run("127.0.0.1", Some(7777));
-            return match result {
-                Ok(()) => Ok(()),
-                Err(error) => {
-                    match error.kind() {
-                        ErrorKind::AddrInUse => {
-                            let _ = sndr.send("AddrInUse");
-                        }
-                        ErrorKind::NotFound => {
-                            let _ = sndr.send("NotFound");
-                        }
-                        _ => {
-                            let _ = sndr.send("Others");
-                        }
-                    }
-                    Err(Box::new(error))
-                }
-            };
-        });
-        let _ = reqwest::get("http://127.0.0.1:7777/notFound");
-        assert_eq!("NotFound", rcvr.recv().unwrap());
-    }
-
-    #[test]
     fn test_request_succeed_with_200() {
-        thread::sleep(time::Duration::from_millis(2000));
         let _ = thread::spawn(|| {
             let _ = super::run("127.0.0.1", Some(8888));
         });
         let res = reqwest::get("http://127.0.0.1:8888");
         assert_eq!(res.unwrap().status().to_string(), "200 OK");
+    }
+
+    #[test]
+    fn test_request_fail_with_404() {
+        let _ = thread::spawn(|| {
+            let _ = super::run("127.0.0.1", Some(9999));
+        });
+        let res = reqwest::get("http://127.0.0.1:9999/notExistUrl");
+        assert_eq!(res.unwrap().status().to_string(), "404 Not Found");
     }
 }
 


### PR DESCRIPTION
### 요약

* 에러 테스트 코드 작성

    * 통신 포트(7878) 사용 중인 경우: `io::ErrorKind::AddrInUse` 에러가 발생

    * 응답 처리에 필요한 자원이 없는 경우: `io::ErrorKind::NotFound` 에러가 발생

* 2번째 테스트(NotFound error)의 경우 비동기 처리를 위해 별도의 스레드 생성

* 테스트 코드 내부에서 http request 발생을 위해 reqwest(ver 0.9) 라이브러리 사용

* 비동기 테스트는 지원되지 않음 (reqwet:get(). await -> async fun 사용시 에러)

### 참고 자료 

* [테스트 코드 작성](https://doc.rust-lang.org/book/ch11-02-running-tests.html#showing-function-output)
* [쓰레드간 통신 채널](https://doc.rust-lang.org/std/sync/mpsc/)
* [에러 assertion](https://stackoverflow.com/questions/57234140/how-to-assert-errors-in-rust)
* [reqwest 라이브러리](https://docs.rs/reqwest/0.10.4/reqwest/)

### Todo 

* 멀티 스레드 서버 코드 작성